### PR TITLE
DCPL-4052 upgrade spring to version 7.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,9 @@ ECLIPSE GEMINI BLUEPRINT CHANGELOG
 ==================================
 http://www.eclipse.org/gemini/blueprint
 
+Changes in version 5.0.0 (2026-04-24)
+* Migrate to spring 7
+
 Changes in version 3.0.0.M01 (2018-04-02)
 -----------------------------------------
 
@@ -56,7 +59,7 @@ Changes in version 2.0.0.M02 (2013-03-20)
 
 General:
 * Bug 403628 - Support optional synchronous application context shutdown
-* Bug 384166 - Extend resource retrieval to both backing bundle and bridge classloader 
+* Bug 384166 - Extend resource retrieval to both backing bundle and bridge classloader
 
 Changes in version 2.0.0.M01 (2013-02-12)
 -----------------------------------------

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extender/pom.xml
+++ b/extender/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extender/pom.xml
+++ b/extender/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extender/pom.xml
+++ b/extender/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/config.bundle/pom.xml
+++ b/integration-tests/bundles/blueprint/config.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt.blueprint</groupId>
         <artifactId>bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/config.bundle/pom.xml
+++ b/integration-tests/bundles/blueprint/config.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt.blueprint</groupId>
         <artifactId>bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/config.bundle/pom.xml
+++ b/integration-tests/bundles/blueprint/config.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt.blueprint</groupId>
         <artifactId>bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/error.bundle/pom.xml
+++ b/integration-tests/bundles/blueprint/error.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt.blueprint</groupId>
         <artifactId>bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/error.bundle/pom.xml
+++ b/integration-tests/bundles/blueprint/error.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt.blueprint</groupId>
         <artifactId>bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/error.bundle/pom.xml
+++ b/integration-tests/bundles/blueprint/error.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt.blueprint</groupId>
         <artifactId>bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/pom.xml
+++ b/integration-tests/bundles/blueprint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/pom.xml
+++ b/integration-tests/bundles/blueprint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/pom.xml
+++ b/integration-tests/bundles/blueprint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/simple.bundle/pom.xml
+++ b/integration-tests/bundles/blueprint/simple.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt.blueprint</groupId>
         <artifactId>bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/simple.bundle/pom.xml
+++ b/integration-tests/bundles/blueprint/simple.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt.blueprint</groupId>
         <artifactId>bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/simple.bundle/pom.xml
+++ b/integration-tests/bundles/blueprint/simple.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt.blueprint</groupId>
         <artifactId>bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/waiting.bundle/pom.xml
+++ b/integration-tests/bundles/blueprint/waiting.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt.blueprint</groupId>
         <artifactId>bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/waiting.bundle/pom.xml
+++ b/integration-tests/bundles/blueprint/waiting.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt.blueprint</groupId>
         <artifactId>bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/blueprint/waiting.bundle/pom.xml
+++ b/integration-tests/bundles/blueprint/waiting.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt.blueprint</groupId>
         <artifactId>bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/cardinality.0to1.bundle/pom.xml
+++ b/integration-tests/bundles/cardinality.0to1.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/cardinality.0to1.bundle/pom.xml
+++ b/integration-tests/bundles/cardinality.0to1.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/cardinality.0to1.bundle/pom.xml
+++ b/integration-tests/bundles/cardinality.0to1.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/async.nowait.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/async.nowait.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/async.nowait.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/async.nowait.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/async.nowait.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/async.nowait.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/async.wait.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/async.wait.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/async.wait.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/async.wait.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/async.wait.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/async.wait.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/no.publish.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/no.publish.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/no.publish.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/no.publish.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/no.publish.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/no.publish.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/sync.nowait.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/sync.nowait.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/sync.nowait.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/sync.nowait.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/sync.nowait.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/sync.nowait.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/sync.tail.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/sync.tail.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/sync.tail.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/sync.tail.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/sync.tail.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/sync.tail.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/sync.wait.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/sync.wait.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/sync.wait.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/sync.wait.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.bundle/sync.wait.bundle/pom.xml
+++ b/integration-tests/bundles/config.bundle/sync.wait.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>config.bundle</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.file.with.dots.bundle/pom.xml
+++ b/integration-tests/bundles/config.file.with.dots.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.file.with.dots.bundle/pom.xml
+++ b/integration-tests/bundles/config.file.with.dots.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/config.file.with.dots.bundle/pom.xml
+++ b/integration-tests/bundles/config.file.with.dots.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/configuration.test.bundle/pom.xml
+++ b/integration-tests/bundles/configuration.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/configuration.test.bundle/pom.xml
+++ b/integration-tests/bundles/configuration.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/configuration.test.bundle/pom.xml
+++ b/integration-tests/bundles/configuration.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/deadlock.bundle/pom.xml
+++ b/integration-tests/bundles/deadlock.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/deadlock.bundle/pom.xml
+++ b/integration-tests/bundles/deadlock.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/deadlock.bundle/pom.xml
+++ b/integration-tests/bundles/deadlock.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/dependency.factory.bundle/pom.xml
+++ b/integration-tests/bundles/dependency.factory.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/dependency.factory.bundle/pom.xml
+++ b/integration-tests/bundles/dependency.factory.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/dependency.factory.bundle/pom.xml
+++ b/integration-tests/bundles/dependency.factory.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/dependency.test.bundle/pom.xml
+++ b/integration-tests/bundles/dependency.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/dependency.test.bundle/pom.xml
+++ b/integration-tests/bundles/dependency.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/dependency.test.bundle/pom.xml
+++ b/integration-tests/bundles/dependency.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/error.bundle/pom.xml
+++ b/integration-tests/bundles/error.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/error.bundle/pom.xml
+++ b/integration-tests/bundles/error.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/error.bundle/pom.xml
+++ b/integration-tests/bundles/error.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/export.import.dependency.bundle/pom.xml
+++ b/integration-tests/bundles/export.import.dependency.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/export.import.dependency.bundle/pom.xml
+++ b/integration-tests/bundles/export.import.dependency.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/export.import.dependency.bundle/pom.xml
+++ b/integration-tests/bundles/export.import.dependency.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/extender.fragment.bundle/pom.xml
+++ b/integration-tests/bundles/extender.fragment.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/extender.fragment.bundle/pom.xml
+++ b/integration-tests/bundles/extender.fragment.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/extender.fragment.bundle/pom.xml
+++ b/integration-tests/bundles/extender.fragment.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/extender.listener.bundle/pom.xml
+++ b/integration-tests/bundles/extender.listener.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/extender.listener.bundle/pom.xml
+++ b/integration-tests/bundles/extender.listener.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/extender.listener.bundle/pom.xml
+++ b/integration-tests/bundles/extender.listener.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/extender.version.bundle/pom.xml
+++ b/integration-tests/bundles/extender.version.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/extender.version.bundle/pom.xml
+++ b/integration-tests/bundles/extender.version.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/extender.version.bundle/pom.xml
+++ b/integration-tests/bundles/extender.version.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/io.fragment.1.bundle/pom.xml
+++ b/integration-tests/bundles/io.fragment.1.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/io.fragment.1.bundle/pom.xml
+++ b/integration-tests/bundles/io.fragment.1.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/io.fragment.1.bundle/pom.xml
+++ b/integration-tests/bundles/io.fragment.1.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/io.fragment.2.bundle/pom.xml
+++ b/integration-tests/bundles/io.fragment.2.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/io.fragment.2.bundle/pom.xml
+++ b/integration-tests/bundles/io.fragment.2.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/io.fragment.2.bundle/pom.xml
+++ b/integration-tests/bundles/io.fragment.2.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/jdk.proxy.bundle/pom.xml
+++ b/integration-tests/bundles/jdk.proxy.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/jdk.proxy.bundle/pom.xml
+++ b/integration-tests/bundles/jdk.proxy.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/jdk.proxy.bundle/pom.xml
+++ b/integration-tests/bundles/jdk.proxy.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/jdk5/component.scan.bundle/pom.xml
+++ b/integration-tests/bundles/jdk5/component.scan.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>spring-osgi-jdk5-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/jdk5/component.scan.bundle/pom.xml
+++ b/integration-tests/bundles/jdk5/component.scan.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>spring-osgi-jdk5-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/jdk5/component.scan.bundle/pom.xml
+++ b/integration-tests/bundles/jdk5/component.scan.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>spring-osgi-jdk5-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/jdk5/pom.xml
+++ b/integration-tests/bundles/jdk5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/jdk5/pom.xml
+++ b/integration-tests/bundles/jdk5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/jdk5/pom.xml
+++ b/integration-tests/bundles/jdk5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/lifecycle.test.bundle/pom.xml
+++ b/integration-tests/bundles/lifecycle.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/lifecycle.test.bundle/pom.xml
+++ b/integration-tests/bundles/lifecycle.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/lifecycle.test.bundle/pom.xml
+++ b/integration-tests/bundles/lifecycle.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/namespace.own.consumer.bundle/pom.xml
+++ b/integration-tests/bundles/namespace.own.consumer.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/namespace.own.consumer.bundle/pom.xml
+++ b/integration-tests/bundles/namespace.own.consumer.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/namespace.own.consumer.bundle/pom.xml
+++ b/integration-tests/bundles/namespace.own.consumer.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/pom.xml
+++ b/integration-tests/bundles/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-tests-parent</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/pom.xml
+++ b/integration-tests/bundles/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-tests-parent</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/pom.xml
+++ b/integration-tests/bundles/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-tests-parent</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/proxy.creator.bundle/pom.xml
+++ b/integration-tests/bundles/proxy.creator.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/proxy.creator.bundle/pom.xml
+++ b/integration-tests/bundles/proxy.creator.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/proxy.creator.bundle/pom.xml
+++ b/integration-tests/bundles/proxy.creator.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/proxy.destruction.test.bundle/pom.xml
+++ b/integration-tests/bundles/proxy.destruction.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/proxy.destruction.test.bundle/pom.xml
+++ b/integration-tests/bundles/proxy.destruction.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/proxy.destruction.test.bundle/pom.xml
+++ b/integration-tests/bundles/proxy.destruction.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/proxy.listener/pom.xml
+++ b/integration-tests/bundles/proxy.listener/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/proxy.listener/pom.xml
+++ b/integration-tests/bundles/proxy.listener/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/proxy.listener/pom.xml
+++ b/integration-tests/bundles/proxy.listener/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/recursive.type.bundle/pom.xml
+++ b/integration-tests/bundles/recursive.type.bundle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.gemini.blueprint.iandt</groupId>
 		<artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-		<version>5.0.0-atlassian-1-SNAPSHOT</version>
+		<version>5.0.0-atlassian-1-624e6bb</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/integration-tests/bundles/recursive.type.bundle/pom.xml
+++ b/integration-tests/bundles/recursive.type.bundle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.gemini.blueprint.iandt</groupId>
 		<artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-		<version>4.0.0-atlassian-9-SNAPSHOT</version>
+		<version>5.0.0-atlassian-1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/integration-tests/bundles/recursive.type.bundle/pom.xml
+++ b/integration-tests/bundles/recursive.type.bundle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.gemini.blueprint.iandt</groupId>
 		<artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-		<version>5.0.0-atlassian-1-624e6bb</version>
+		<version>5.0.0-atlassian-1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/integration-tests/bundles/reference.test.bundle/pom.xml
+++ b/integration-tests/bundles/reference.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/reference.test.bundle/pom.xml
+++ b/integration-tests/bundles/reference.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/reference.test.bundle/pom.xml
+++ b/integration-tests/bundles/reference.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/scoped.a.bundle/pom.xml
+++ b/integration-tests/bundles/scoped.a.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/scoped.a.bundle/pom.xml
+++ b/integration-tests/bundles/scoped.a.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/scoped.a.bundle/pom.xml
+++ b/integration-tests/bundles/scoped.a.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/scoped.b.bundle/pom.xml
+++ b/integration-tests/bundles/scoped.b.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/scoped.b.bundle/pom.xml
+++ b/integration-tests/bundles/scoped.b.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/scoped.b.bundle/pom.xml
+++ b/integration-tests/bundles/scoped.b.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/scoped.common.bundle/pom.xml
+++ b/integration-tests/bundles/scoped.common.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/scoped.common.bundle/pom.xml
+++ b/integration-tests/bundles/scoped.common.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/scoped.common.bundle/pom.xml
+++ b/integration-tests/bundles/scoped.common.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/service.listener.bundle/pom.xml
+++ b/integration-tests/bundles/service.listener.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/service.listener.bundle/pom.xml
+++ b/integration-tests/bundles/service.listener.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/service.listener.bundle/pom.xml
+++ b/integration-tests/bundles/service.listener.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.2.bundle/pom.xml
+++ b/integration-tests/bundles/simple.service.2.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.2.bundle/pom.xml
+++ b/integration-tests/bundles/simple.service.2.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.2.bundle/pom.xml
+++ b/integration-tests/bundles/simple.service.2.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.3.bundle/pom.xml
+++ b/integration-tests/bundles/simple.service.3.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.3.bundle/pom.xml
+++ b/integration-tests/bundles/simple.service.3.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.3.bundle/pom.xml
+++ b/integration-tests/bundles/simple.service.3.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.bundle.2.identical/pom.xml
+++ b/integration-tests/bundles/simple.service.bundle.2.identical/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.bundle.2.identical/pom.xml
+++ b/integration-tests/bundles/simple.service.bundle.2.identical/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.bundle.2.identical/pom.xml
+++ b/integration-tests/bundles/simple.service.bundle.2.identical/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.bundle.identical/pom.xml
+++ b/integration-tests/bundles/simple.service.bundle.identical/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.bundle.identical/pom.xml
+++ b/integration-tests/bundles/simple.service.bundle.identical/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.bundle.identical/pom.xml
+++ b/integration-tests/bundles/simple.service.bundle.identical/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.bundle/pom.xml
+++ b/integration-tests/bundles/simple.service.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.bundle/pom.xml
+++ b/integration-tests/bundles/simple.service.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/simple.service.bundle/pom.xml
+++ b/integration-tests/bundles/simple.service.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/tccl.bundle/pom.xml
+++ b/integration-tests/bundles/tccl.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/tccl.bundle/pom.xml
+++ b/integration-tests/bundles/tccl.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/tccl.bundle/pom.xml
+++ b/integration-tests/bundles/tccl.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/tccl.intf.bundle/pom.xml
+++ b/integration-tests/bundles/tccl.intf.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/tccl.intf.bundle/pom.xml
+++ b/integration-tests/bundles/tccl.intf.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/tccl.intf.bundle/pom.xml
+++ b/integration-tests/bundles/tccl.intf.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/trivial.bundle/pom.xml
+++ b/integration-tests/bundles/trivial.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/trivial.bundle/pom.xml
+++ b/integration-tests/bundles/trivial.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/trivial.bundle/pom.xml
+++ b/integration-tests/bundles/trivial.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/trivial.test.bundle/pom.xml
+++ b/integration-tests/bundles/trivial.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/trivial.test.bundle/pom.xml
+++ b/integration-tests/bundles/trivial.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/bundles/trivial.test.bundle/pom.xml
+++ b/integration-tests/bundles/trivial.test.bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-test-bundles</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint</groupId>
         <artifactId>gemini-blueprint</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint</groupId>
         <artifactId>gemini-blueprint</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint</groupId>
         <artifactId>gemini-blueprint</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/tests/pom.xml
+++ b/integration-tests/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-tests-parent</artifactId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/tests/pom.xml
+++ b/integration-tests/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-tests-parent</artifactId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/tests/pom.xml
+++ b/integration-tests/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.gemini.blueprint.iandt</groupId>
         <artifactId>gemini-blueprint-integration-tests-parent</artifactId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/io/pom.xml
+++ b/io/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/io/pom.xml
+++ b/io/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/io/pom.xml
+++ b/io/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mock/pom.xml
+++ b/mock/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mock/pom.xml
+++ b/mock/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mock/pom.xml
+++ b/mock/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.eclipse.gemini.blueprint</groupId>
     <artifactId>gemini-blueprint</artifactId>
     <!-- Note: When updating the version, ensure it is a valid OSGi version -->
-    <version>4.0.0-atlassian-9-SNAPSHOT</version>
+    <version>5.0.0-atlassian-1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Gemini Blueprint</name>
     <url>http://www.eclipse.org/gemini/blueprint/</url>
@@ -23,8 +23,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Spring version -->
-        <spring.maven.artifact.version>6.2.0</spring.maven.artifact.version>
-        <spring.base.version>6.0.0</spring.base.version>
+        <spring.maven.artifact.version>7.0.7</spring.maven.artifact.version>
+        <spring.base.version>7.0.0</spring.base.version>
 
         <symName.prefix>org.eclipse.gemini.blueprint</symName.prefix>
         <spring.osgi.symbolic.name>${project.groupId}.${project.artifactId}</spring.osgi.symbolic.name>
@@ -55,7 +55,7 @@
         <policy.url>..${file.separator}policy.all</policy.url>
 
         <!-- common version ranges -->
-        <spring.version.range.nq>[${spring.base.version},7)</spring.version.range.nq>
+        <spring.version.range.nq>[${spring.base.version},8)</spring.version.range.nq>
         <spring.version.range>"${spring.version.range.nq}"</spring.version.range>
         <gemini.blueprint.version.range.nq>[${project.version},${project.version}]</gemini.blueprint.version.range.nq>
         <gemini.blueprint.version.range>"${gemini.blueprint.version.range.nq}"</gemini.blueprint.version.range>
@@ -232,6 +232,12 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
                 <version>${spring.maven.artifact.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -293,7 +299,7 @@
             <dependency>
                 <groupId>com.atlassian.platform.dependencies</groupId>
                 <artifactId>platform-spring-bundle</artifactId>
-                <version>8.0.0-jakarta-001</version>
+                <version>9.0.0-m010</version>
             </dependency>
 
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.eclipse.gemini.blueprint</groupId>
     <artifactId>gemini-blueprint</artifactId>
     <!-- Note: When updating the version, ensure it is a valid OSGi version -->
-    <version>5.0.0-atlassian-1-624e6bb</version>
+    <version>5.0.0-atlassian-1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Gemini Blueprint</name>
     <url>http://www.eclipse.org/gemini/blueprint/</url>
@@ -96,7 +96,7 @@
         <url>https://github.com/atlassian-forks/gemini.blueprint</url>
         <connection>scm:git:git@github.com:atlassian-forks/gemini.blueprint.git</connection>
         <developerConnection>scm:git:git@github.com:atlassian-forks/gemini.blueprint.git</developerConnection>
-        <tag>gemini-blueprint-5.0.0-atlassian-1-624e6bb</tag>
+        <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.eclipse.gemini.blueprint</groupId>
     <artifactId>gemini-blueprint</artifactId>
     <!-- Note: When updating the version, ensure it is a valid OSGi version -->
-    <version>5.0.0-atlassian-1-SNAPSHOT</version>
+    <version>5.0.0-atlassian-1-624e6bb</version>
     <packaging>pom</packaging>
     <name>Gemini Blueprint</name>
     <url>http://www.eclipse.org/gemini/blueprint/</url>
@@ -96,7 +96,7 @@
         <url>https://github.com/atlassian-forks/gemini.blueprint</url>
         <connection>scm:git:git@github.com:atlassian-forks/gemini.blueprint.git</connection>
         <developerConnection>scm:git:git@github.com:atlassian-forks/gemini.blueprint.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>gemini-blueprint-5.0.0-atlassian-1-624e6bb</tag>
   </scm>
 
     <developers>

--- a/test-support/pom.xml
+++ b/test-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>5.0.0-atlassian-1-624e6bb</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/test-support/pom.xml
+++ b/test-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>5.0.0-atlassian-1-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-624e6bb</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/test-support/pom.xml
+++ b/test-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gemini-blueprint</artifactId>
         <groupId>org.eclipse.gemini.blueprint</groupId>
-        <version>4.0.0-atlassian-9-SNAPSHOT</version>
+        <version>5.0.0-atlassian-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/test-support/src/main/resources/org/eclipse/gemini/blueprint/test/internal/boot-bundles.properties
+++ b/test-support/src/main/resources/org/eclipse/gemini/blueprint/test/internal/boot-bundles.properties
@@ -9,7 +9,7 @@
 # elements that have to be ignored should star with
 # ignore
 
-# Note: inner placeholders are not supported. 
+# Note: inner placeholders are not supported.
 
 #
 # common properties
@@ -19,7 +19,7 @@
 ignore.junit.version=4.12_1
 ignore.logback.version=1.0.13
 
-ignore.atlassian.spring.bundle.version=8.0.0-jakarta-001
+ignore.atlassian.spring.bundle.version=9.0.0-m010
 ignore.gemini.blueprint.version=${project.version}
 ignore.slf4j.version=1.7.5
 ignore.assertj.version=3.6.2


### PR DESCRIPTION
Bump spring to version 7.
IMO this is a breaking change as `Import-Package` for spring changes required versions.
I've bumped the major version + created `release/4.0.x` branch from current `main`

Compare with the previous PR (we are using version released from this branch in the platform right now): https://github.com/atlassian-forks/gemini.blueprint/compare/main...atlassian-forks:gemini.blueprint:issue/main/DCPL-3462-spring-7