### PR TITLE
VULN-2263481: Upgraded spring-expression to 7.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Spring version -->
-        <spring.maven.artifact.version>7.0.7</spring.maven.artifact.version>
+        <spring.maven.artifact.version>7.0.8</spring.maven.artifact.version>
         <spring.base.version>7.0.0</spring.base.version>
 
         <symName.prefix>org.eclipse.gemini.blueprint</symName.prefix>


### PR DESCRIPTION
Bumping spring-expression to 7.0.8 to fix https://spring.io/security/cve-2026-41850